### PR TITLE
datadog agent not detecting additional configs in /{checks.d,conf.d} …

### DIFF
--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -120,13 +120,13 @@ spec:
             readOnly: true
           {{- if (or (.Values.datadog.confd) (.Values.datadog.autoconf)) }}
           - name: confd
-            mountPath: /conf.d
+            mountPath: {{ .Values.datadog.confdMountPath }}
             readOnly: true
           {{- end }}
           {{- if .Values.datadog.checksd }}
           - name: checksd
-            mountPath: /checks.d
-            readOnly: true
+    mountPath: {{ .Values.datadog.checksdMountPath }}
+    readOnly: true
           {{- end }}
           {{- if .Values.datadog.logsEnabled }}
           - name: pointerdir

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -61,6 +61,8 @@ spec:
               secretKeyRef:
                 name: {{ template "datadog.apiSecretName" . }}
                 key: api-key
+          - name: DD_ETC_ROOT
+            value: {{ .Values.datadog.etc_root }}
           {{- if .Values.datadog.logLevel }}
           - name: DD_LOG_LEVEL
             value: {{ .Values.datadog.logLevel | quote }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -159,6 +159,19 @@ datadog:
   ##
   # leaderLeaseDuration: 600
 
+  ## checks.d and conf.d additional configurations
+
+  ## Set the configMap volume mountPath per
+
+  ## conf.d
+
+  confdMountPath: /conf.d
+
+  ## checks.d
+
+  checksdMountPath: /checks.d
+
+  ## 
   ## Provide additional check configurations (static and Autodiscovery)
   ## Each key will become a file in /conf.d
   ## ref: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/agent#optional-volumes

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -104,6 +104,9 @@ datadog:
   ##
   logLevel: WARNING
 
+  ## Set configuration root in `/etc/`
+  etc_root: /etc/datadog-agent
+
   ## Un-comment this to make each node accept non-local statsd traffic.
   ## ref: https://github.com/DataDog/docker-dd-agent#environment-variables
   ##


### PR DESCRIPTION
datadog agent not detecting additional configs in `/{checks.d,conf.d}`- per log message, because
the root of this problem is that `${DD_ETC_ROOT}` is not set in the helm chart, and also there essentially no check if an end user uses a `.yml` file extension versus the `.yaml` as hard-coded in the file command. See: https://github.com/DataDog/docker-dd-agent/blob/master/entrypoint.sh#L93


this PR provides direct flexibility about defining where the additional configs are mounted inside the containers filesystem. This PR leaves the default values intact so there are no breaking changes. Now additional configs can be mounted as volumes to a path a user can specify.

the following values are introduced:

* `datadog.confdmountPath`
* `datadog.checksdmountPath`
